### PR TITLE
Rename LoadingActivity.kt. Move SedangTayangActivity.kt. Modified AndroidManifest.xml, OnBoardingPageOneActivity.kt, OnBoardingPageTwoActivity.kt, OnboardPageThreeActivity.kt, strings.xml.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
             android:name=".AkanTayangActivity"
             android:exported="false" />
         <activity
-            android:name=".model.SedangTayangActivity"
+            android:name=".SedangTayangActivity"
             android:exported="false" />
         <activity
             android:name=".SeatSelecionActivity"
@@ -59,6 +59,7 @@
             android:exported="false" />
         <activity
             android:name=".HomeActivity"
+            android:windowSoftInputMode="adjustPan"
             android:exported="false" />
         <activity
             android:name=".TicketActivity"
@@ -67,7 +68,7 @@
             android:name=".WishlistMovieActivity"
             android:exported="false" />
         <activity
-            android:name=".LoadingActivity"
+            android:name=".SplashActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -75,9 +76,6 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity
-            android:name=".MainActivity"
-            android:exported="false" />
         <activity
             android:name=".ProfileActivity"
             android:exported="false" />

--- a/app/src/main/java/com/garpoo/cinatix/OnBoardingPageOneActivity.kt
+++ b/app/src/main/java/com/garpoo/cinatix/OnBoardingPageOneActivity.kt
@@ -1,20 +1,27 @@
 package com.garpoo.cinatix
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
+import com.garpoo.cinatix.databinding.ActivityOnBoardingPageOneBinding
 
 class OnBoardingPageOneActivity : AppCompatActivity() {
+
+    lateinit var binding: ActivityOnBoardingPageOneBinding
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        setContentView(R.layout.activity_on_boarding_page_one)
-        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
-            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
-            insets
+        binding = ActivityOnBoardingPageOneBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        binding.nextButton.setOnClickListener {
+            val intent = Intent(this, OnBoardingPageTwoActivity::class.java)
+            startActivity(intent)
+            finish()
+        }
+        binding.skipButton.setOnClickListener {
+            val intent = Intent(this, SignInActivity::class.java)
+            startActivity(intent)
         }
     }
 }

--- a/app/src/main/java/com/garpoo/cinatix/OnBoardingPageTwoActivity.kt
+++ b/app/src/main/java/com/garpoo/cinatix/OnBoardingPageTwoActivity.kt
@@ -1,20 +1,25 @@
 package com.garpoo.cinatix
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
+import com.garpoo.cinatix.databinding.ActivityOnBoardingPageTwoBinding
 
 class OnBoardingPageTwoActivity : AppCompatActivity() {
+
+    lateinit var binding: ActivityOnBoardingPageTwoBinding
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        setContentView(R.layout.activity_on_boarding_page_two)
-        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
-            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
-            insets
+        setContentView(binding.root)
+        binding.nextButton.setOnClickListener {
+            val intent = Intent(this, OnboardPageThreeActivity::class.java)
+            startActivity(intent)
+        }
+        binding.skipButton.setOnClickListener {
+            val intent = Intent(this, SignInActivity::class.java)
+            startActivity(intent)
         }
     }
 }

--- a/app/src/main/java/com/garpoo/cinatix/OnboardPageThreeActivity.kt
+++ b/app/src/main/java/com/garpoo/cinatix/OnboardPageThreeActivity.kt
@@ -1,20 +1,25 @@
 package com.garpoo.cinatix
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
+import com.garpoo.cinatix.databinding.ActivityOnboardPageThreeBinding
 
 class OnboardPageThreeActivity : AppCompatActivity() {
+
+    lateinit var binding: ActivityOnboardPageThreeBinding
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        setContentView(R.layout.activity_onboard_page_three)
-        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
-            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
-            insets
+        setContentView(binding.root)
+        binding.nextButton.setOnClickListener {
+            val intent = Intent(this, SignInActivity::class.java)
+            startActivity(intent)
+        }
+        binding.skipButton.setOnClickListener {
+            val intent = Intent(this, SignInActivity::class.java)
+            startActivity(intent)
         }
     }
 }

--- a/app/src/main/java/com/garpoo/cinatix/SedangTayangActivity.kt
+++ b/app/src/main/java/com/garpoo/cinatix/SedangTayangActivity.kt
@@ -1,11 +1,10 @@
-package com.garpoo.cinatix.model
+package com.garpoo.cinatix
 
 import android.os.Bundle
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import com.garpoo.cinatix.R
 
 class SedangTayangActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/garpoo/cinatix/SplashActivity.kt
+++ b/app/src/main/java/com/garpoo/cinatix/SplashActivity.kt
@@ -9,7 +9,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 
-class LoadingActivity : AppCompatActivity() {
+class SplashActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()

--- a/app/src/main/res/layout/activity_loading.xml
+++ b/app/src/main/res/layout/activity_loading.xml
@@ -5,7 +5,7 @@
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".LoadingActivity">
+    tools:context=".SplashActivity">
 
     <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/iv_logo"

--- a/app/src/main/res/layout/activity_sedang_tayang.xml
+++ b/app/src/main/res/layout/activity_sedang_tayang.xml
@@ -5,7 +5,7 @@
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".model.SedangTayangActivity">
+    tools:context=".SedangTayangActivity">
 
     <com.google.android.material.tabs.TabLayout
         android:id="@+id/tab_layout"
@@ -15,7 +15,7 @@
         app:tabIndicatorColor="#FFC107"
         app:tabSelectedTextColor="#000000"
         app:tabTextColor="#999999"
-        app:layout_constraintTop_toBottomOf="@id/search_bar"
+        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         android:layout_marginTop="16dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="shopee_pay">ShopeePay</string>
     <string name="shopee_pay_cashback">Cashback s/d 10rb koin Shopee</string>
     <string name="ovo">OVO</string>
-    <string name="skip"></string>
+    <string name="skip">Skip</string>
 
     <!-- On Boarding Page One Activity -->
     <string name="welcome_one">Welcome to CinaTIX!</string>
@@ -76,7 +76,7 @@
     <string name="watch_trailer">Watch Trailer</string>
     <string name="sinopsis">SINOPSIS</string>
     <string name="jadwal">JADWAL</string>
-    <string name="sinopsis_text">After the death of his mother and sister in a tragic accident, Thomas (Jerome Kurnia) intends to resign as Father. However, he was given the final task of helping the exorcist Father, Rendra (Lukman Sardi), whose health wa...</string>
+    <string name="sinopsis_text">After the death of his mother and sister in a tragic accident, Thomas (Jerome Kurnia) intends to resign as Father. However, he was given the final task of helping the exorcist Father, Rendra (Lukman Sardi), whose health wa…</string>
     <string name="cast_label">Pemeran</string>
     <string name="beli_tiket">BELI TIKET</string>
 


### PR DESCRIPTION
Rename LoadingActivity.kt to SplashActivity.kt. Move SedangTayangActivity.kt from the model folder back to all the activity folder place. And modified activity_sedang_tayang.xml to have the tabs layout top to top constraint to parent because it reference to a widget that doesn't exist. Modified AndroidManifest.xml. Change LoadingActivity to SplashActivity, add an attribute for activity HomeActivity that is window soft input mode so that the layout is not shift up. Delete activity HomeActivity because it doesn't exist. Change SedangTayangActivity name because it's already move from model to the root. Modified OnBoardingPageOneActivity.kt. Remove the padding insets. Add binding variable. Set onclick listener for next button and skip button. Modified OnBoardingPageTwoActivity.kt. Remove the padding insets. Add binding variable. Set onclick listener for next button and skip button. Modified OnboardPageThreeActivity.kt. Remove the padding insets. Add binding variable. Set onclick listener for next button and skip button. Modified strings.xml. For the skip after checking there is nothing in the text. And now I populate it with "Skip".